### PR TITLE
Improve MCP listing metadata and tool schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v5
       - name: Lint
         run: uv run --extra dev ruff check .
@@ -24,7 +24,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v5
       - run: uvx ruff check .
       - run: python3 -m py_compile ableton_live_mcp/remote_script/__init__.py
@@ -22,7 +22,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v5
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -34,7 +34,7 @@ jobs:
       id-token: write   # OIDC auth to the MCP Registry
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Wait for the version to appear on PyPI
         run: |
           VERSION=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Audit pass across the whole server. 154 tools.
 
+- Discovery metadata: added `glama.json`, a Glama quality badge, richer PyPI
+  keywords/project links, and a direct-answer FAQ. Reworked all 29 tools Glama
+  rated B/C with documented input schemas, constraints, side effects, sibling-tool
+  guidance, and accurate idempotent/destructive annotations.
+- Official MCP Registry publishing fixed: `server.json` now keeps its description
+  within the schema's 100-character limit and includes `websiteUrl`. The oversized
+  description had caused every Registry publish after 1.1.1 to fail even though
+  the corresponding PyPI releases succeeded.
 - New tool `delete_return_track` (the handler already existed; the tool was missing).
 - Offline `.als`: track `muted` is read from the track activator (was always
   false), `soloed` from the track-level solo field (was reading a sampler zone),

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/wstierhout/ableton-live-mcp)](https://github.com/wstierhout/ableton-live-mcp/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](pyproject.toml)
+[![Glama tool quality](https://glama.ai/mcp/servers/wstierhout/ableton-live-mcp/badges/score.svg)](https://glama.ai/mcp/servers/wstierhout/ableton-live-mcp)
 
 Control Ableton Live from an AI assistant. This is a Model Context Protocol (MCP)
 server that gives Claude, Cursor, Codex, or any MCP client 154 tools for building
@@ -156,6 +157,39 @@ uvx ruff check .               # lint
 
 CI runs lint, a byte-compile of the Remote Script, and the tests on Python 3.10 and
 3.12.
+
+## Frequently asked questions
+
+### What is the Ableton Live MCP Server?
+
+It is a local Model Context Protocol server that lets AI clients such as Claude,
+Cursor, and Codex inspect and control Ableton Live through typed tools. It can build
+tracks, edit MIDI, load and configure devices, arrange clips, mix a set, and analyze
+saved `.als` projects.
+
+### How is this different from other Ableton MCP servers?
+
+This server exposes 154 specific, validated tools rather than an arbitrary-code
+execution tool. It includes destructive/read-only hints, workflow prompts, built-in
+music generators, mixing and analysis tools, and offline `.als`/`.adg` inspection.
+The Remote Script and MCP package are versioned and tested together.
+
+### Can it work while Ableton Live is closed?
+
+The real-time control tools require Ableton Live and the bundled Remote Script to be
+running. The offline tools can summarize, inspect, lint, extract MIDI from, and diff
+saved `.als`, `.adg`, and `.adv` files without launching Live.
+
+### Which MCP clients are supported?
+
+Any client that can launch a local stdio MCP server can use it, including Claude
+Desktop, Claude Code, Cursor, Codex, and compatible IDEs. The canonical command is
+`uvx mcp-server-ableton-live`.
+
+### Is this an official Ableton product?
+
+No. It is an independent, open-source integration and is not affiliated with or
+endorsed by Ableton.
 
 ## Credits and license
 

--- a/ableton_live_mcp/tools/_util.py
+++ b/ableton_live_mcp/tools/_util.py
@@ -1,4 +1,110 @@
-"""Shared helpers for tool modules."""
+"""Shared helpers and JSON-schema types for tool modules."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+# FastMCP preserves Pydantic metadata from ``Annotated`` in each tool's input
+# schema.  Keep the conventions here so agents see the same index, unit, and
+# range guidance on every tool instead of having to infer it from prose.
+TrackIndex = Annotated[
+    int,
+    Field(ge=0, description="Zero-based index of a regular track in the Live set."),
+]
+ClipIndex = Annotated[
+    int,
+    Field(ge=0, description="Zero-based Session-view clip-slot index on the track."),
+]
+SceneIndex = Annotated[
+    int,
+    Field(ge=0, description="Zero-based Session-view scene (row) index."),
+]
+ReturnIndex = Annotated[
+    int,
+    Field(ge=0, description="Zero-based return-track index; 0 is Return A."),
+]
+DeviceIndex = Annotated[
+    int,
+    Field(ge=0, description="Zero-based device position in the target track's device chain."),
+]
+TrackInsertIndex = Annotated[
+    int,
+    Field(
+        ge=-1,
+        description="Insertion position among regular tracks; -1 appends at the end.",
+    ),
+]
+ColorIndex = Annotated[
+    int,
+    Field(ge=0, le=69, description="Color index in Live's 70-color palette (0-69)."),
+]
+PanValue = Annotated[
+    float,
+    Field(ge=-1, le=1, description="Pan position from -1.0 (left) to 1.0 (right)."),
+]
+CrossfadeAssignment = Annotated[
+    int,
+    Field(ge=0, le=2, description="Crossfader assignment: 0 is A, 1 is none, 2 is B."),
+]
+ArrangementBeat = Annotated[
+    float,
+    Field(ge=0, description="Position in beats from the start of the Arrangement."),
+]
+OptionalClipBeat = Annotated[
+    float | None,
+    Field(ge=0, description="Optional position in beats from the start of the clip."),
+]
+PositiveBeatLength = Annotated[
+    float,
+    Field(gt=0, description="Positive duration or region length in beats."),
+]
+DeviceParameter = Annotated[
+    str | int,
+    Field(
+        description=(
+            "Parameter name or zero-based parameter index returned by the matching "
+            "get_*_device_parameters tool."
+        )
+    ),
+]
+DeviceParameterValue = Annotated[
+    float,
+    Field(
+        description=(
+            "Value in the parameter's native range; the server clamps it to the min/max "
+            "reported by the matching get_*_device_parameters tool."
+        )
+    ),
+]
+BrowserItemUri = Annotated[
+    str,
+    Field(description="Loadable browser-item URI returned by search_browser."),
+]
+BrowserPath = Annotated[
+    str,
+    Field(description='Slash-separated Live browser path, such as "drums/acoustic".'),
+]
+DisplayName = Annotated[str, Field(description="New display name for the Live object.")]
+OptionalDisplayName = Annotated[
+    str | None,
+    Field(description="Optional display name; omit it to keep Live's generated name."),
+]
+ToggleState = Annotated[
+    bool,
+    Field(description="True turns the requested state on; false turns it off."),
+]
+OptionalToggleState = Annotated[
+    bool | None,
+    Field(description="Optional state change: true turns it on, false turns it off."),
+]
+TimeSignatureNumerator = Annotated[
+    int,
+    Field(ge=1, description="Number of beats per bar, such as 4 in 4/4."),
+]
+TimeSignatureDenominator = Annotated[
+    int,
+    Field(ge=1, description="Beat-note denominator, such as 4 in 4/4 or 8 in 6/8."),
+]
 
 
 def params(**kw):

--- a/ableton_live_mcp/tools/arrangement.py
+++ b/ableton_live_mcp/tools/arrangement.py
@@ -7,6 +7,7 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import get_ableton_connection
+from ._util import ClipIndex, DeviceIndex, DeviceParameter, TrackIndex
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
@@ -127,11 +128,21 @@ def write_automation(
     return f"Wrote {r.get('point_count')} automation points for {r.get('parameter')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
 def clear_automation(
-    ctx: Context, track_index: int, clip_index: int, device_index: int, parameter: str | int
+    ctx: Context,
+    track_index: TrackIndex,
+    clip_index: ClipIndex,
+    device_index: DeviceIndex,
+    parameter: DeviceParameter,
 ) -> str:
-    """Clear the clip automation envelope for a device parameter."""
+    """Delete one device parameter's entire automation envelope from a clip.
+
+    Resolve the device and parameter with get_device_parameters first. This
+    removes every automation point for that parameter, not a time range; manual
+    parameter state remains. Use write_automation to replace the envelope with
+    new points, or undo immediately to recover an accidental clear.
+    """
     r = get_ableton_connection().send_command(
         "clear_automation",
         {

--- a/ableton_live_mcp/tools/browser.py
+++ b/ableton_live_mcp/tools/browser.py
@@ -7,7 +7,7 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import AbletonCommandError, get_ableton_connection, logger
-from ._util import params
+from ._util import BrowserItemUri, BrowserPath, TrackIndex, params
 
 
 def _translate_browser_error(e: Exception, doing: str) -> Exception:
@@ -111,16 +111,20 @@ def get_browser_items_at_path(ctx: Context, path: str) -> str:
         raise _translate_browser_error(e, "getting browser items at path") from e
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) -> str:
-    """
-    Load a drum rack and then load a specific drum kit into it.
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def load_drum_kit(
+    ctx: Context,
+    track_index: TrackIndex,
+    rack_uri: BrowserItemUri,
+    kit_path: BrowserPath,
+) -> str:
+    """Load a Drum Rack, then the first loadable kit at a browser path.
 
-    Parameters:
-    - track_index: The index of the track to load on
-    - rack_uri: URI of the drum rack to load, as returned by search_browser
-                (e.g. 'query:Drums#Drum%20Rack')
-    - kit_path: Path to the drum kit inside the browser (e.g. 'drums/acoustic/kit1')
+    Use search_browser to obtain the rack URI and get_browser_items_at_path to
+    verify the kit path. This is a two-step mutation: it appends the rack first,
+    then loads the first loadable item found at `kit_path`. If path lookup fails,
+    the new empty rack remains on the track; repeated calls add more racks. Use
+    load_instrument_or_effect when one known browser URI is sufficient.
     """
     ableton = get_ableton_connection()
 

--- a/ableton_live_mcp/tools/clips.py
+++ b/ableton_live_mcp/tools/clips.py
@@ -7,7 +7,15 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import get_ableton_connection
-from ._util import params
+from ._util import (
+    ClipIndex,
+    ColorIndex,
+    DisplayName,
+    OptionalClipBeat,
+    OptionalToggleState,
+    TrackIndex,
+    params,
+)
 
 # Quantize grids, mirroring the Remote Script's _Q_BASE keys (sync-tested in
 # test_dispatch.py). The client pre-check saves a round trip on typos.
@@ -78,15 +86,14 @@ def add_notes_to_clip(
     return f"Added {len(notes)} notes to clip at track {track_index}, slot {clip_index}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) -> str:
-    """
-    Set the name of a clip.
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_clip_name(
+    ctx: Context, track_index: TrackIndex, clip_index: ClipIndex, name: DisplayName
+) -> str:
+    """Rename an existing Session-view clip without changing its notes or audio.
 
-    Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
-    - name: The new name for the clip
+    The slot must contain a clip. Use this for the clip label; use set_track_name
+    for the track label. Repeating the same name has no additional effect.
     """
     ableton = get_ableton_connection()
     ableton.send_command(
@@ -95,14 +102,14 @@ def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) ->
     return f"Renamed clip at track {track_index}, slot {clip_index} to '{name}'"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def fire_clip(ctx: Context, track_index: int, clip_index: int) -> str:
-    """
-    Start playing a clip.
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def fire_clip(ctx: Context, track_index: TrackIndex, clip_index: ClipIndex) -> str:
+    """Launch one existing Session-view clip using Live's launch quantization.
 
-    Parameters:
-    - track_index: The index of the track containing the clip
-    - clip_index: The index of the clip slot containing the clip
+    The slot must contain a clip. Launching it takes Session control of that
+    track and replaces any other playing Session clip on the same track; firing
+    an already-playing clip may retrigger it according to its launch settings.
+    Use fire_scene to launch a whole row, or continue_playing for transport only.
     """
     ableton = get_ableton_connection()
     ableton.send_command("fire_clip", {"track_index": track_index, "clip_index": clip_index})
@@ -124,17 +131,27 @@ def stop_clip(ctx: Context, track_index: int, clip_index: int) -> str:
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
-def delete_clip(ctx: Context, track_index: int, clip_index: int) -> str:
-    """Delete a Session-view clip from a clip slot."""
+def delete_clip(ctx: Context, track_index: TrackIndex, clip_index: ClipIndex) -> str:
+    """Delete the existing Session-view clip in a slot, including its content.
+
+    This leaves the slot empty and does not shift other slot indices. It fails
+    for an empty slot. Use stop_clip if the intent is only to stop playback;
+    use undo immediately if the deletion was accidental.
+    """
     get_ableton_connection().send_command(
         "delete_clip", {"track_index": track_index, "clip_index": clip_index}
     )
     return f"Deleted clip at track {track_index}, slot {clip_index}"
 
 
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-def get_clip_notes(ctx: Context, track_index: int, clip_index: int) -> str:
-    """Read back all MIDI notes in a Session clip."""
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
+def get_clip_notes(ctx: Context, track_index: TrackIndex, clip_index: ClipIndex) -> str:
+    """Return every MIDI note in an existing Session-view MIDI clip.
+
+    Each note includes pitch, start time, duration, velocity, and mute state;
+    newer Live versions may add expression fields. This is read-only and fails
+    for an empty slot or audio clip. Use get_clip_info for clip properties.
+    """
     result = get_ableton_connection().send_command(
         "get_clip_notes", {"track_index": track_index, "clip_index": clip_index}
     )
@@ -205,17 +222,24 @@ def set_clip_audio(
     return f"Applied: {json.dumps(r)}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
 def set_clip_loop(
     ctx: Context,
-    track_index: int,
-    clip_index: int,
-    start: float | None = None,
-    end: float | None = None,
-    start_marker: float | None = None,
-    looping: bool | None = None,
+    track_index: TrackIndex,
+    clip_index: ClipIndex,
+    start: OptionalClipBeat = None,
+    end: OptionalClipBeat = None,
+    start_marker: OptionalClipBeat = None,
+    looping: OptionalToggleState = None,
 ) -> str:
-    """Set a clip's loop braces (start/end beats), start marker, and looping on/off."""
+    """Update selected loop and launch markers on one existing Session clip.
+
+    Provide at least one optional field; omitted fields stay unchanged. `start`
+    and `end` are loop-brace positions in clip-relative beats and end must be
+    after start. `start_marker` controls where non-looped launch begins;
+    `looping` enables or disables repetition. Use set_loop for the Arrangement's
+    global loop region, not a clip, and get_clip_info to inspect current values.
+    """
     opts = params(start=start, end=end, start_marker=start_marker, looping=looping)
     if not opts:
         raise ValueError("Provide at least one property to set")
@@ -247,9 +271,15 @@ def edit_notes(
     return f"Clip now has {r.get('note_count')} notes (added {r.get('added')})"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_clip_color(ctx: Context, track_index: int, clip_index: int, color_index: int) -> str:
-    """Set a clip's color by index (0-69 in Live's palette)."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_clip_color(
+    ctx: Context, track_index: TrackIndex, clip_index: ClipIndex, color_index: ColorIndex
+) -> str:
+    """Set an existing Session clip's palette color without changing its content.
+
+    This is a visual organization change only. Use set_track_color to recolor
+    the track header instead. Repeating the same color has no additional effect.
+    """
     get_ableton_connection().send_command(
         "set_clip_color",
         {"track_index": track_index, "clip_index": clip_index, "color_index": color_index},

--- a/ableton_live_mcp/tools/devices.py
+++ b/ableton_live_mcp/tools/devices.py
@@ -7,7 +7,16 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import get_ableton_connection
-from ._util import params
+from ._util import (
+    BrowserItemUri,
+    DeviceIndex,
+    DeviceParameter,
+    DeviceParameterValue,
+    ReturnIndex,
+    ToggleState,
+    TrackIndex,
+    params,
+)
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
@@ -55,9 +64,20 @@ def set_device_parameter(
     )
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_device_enabled(ctx: Context, track_index: int, device_index: int, enabled: bool) -> str:
-    """Enable or bypass a device on a track."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_device_enabled(
+    ctx: Context,
+    track_index: TrackIndex,
+    device_index: DeviceIndex,
+    enabled: ToggleState,
+) -> str:
+    """Enable or bypass one device on a regular track.
+
+    `true` turns the device on; `false` bypasses its processing while preserving
+    the device and parameter values. This changes audible signal flow but not
+    clip content. Use set_track_mute to silence the whole track, or
+    set_device_parameter to change one control.
+    """
     r = get_ableton_connection().send_command(
         "set_device_enabled",
         {"track_index": track_index, "device_index": device_index, "enabled": enabled},
@@ -65,9 +85,15 @@ def set_device_enabled(ctx: Context, track_index: int, device_index: int, enable
     return f"{r.get('device')} enabled={r.get('enabled')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def load_device_to_return(ctx: Context, return_index: int, item_uri: str) -> str:
-    """Load a device/effect from the browser onto a return track."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def load_device_to_return(ctx: Context, return_index: ReturnIndex, item_uri: BrowserItemUri) -> str:
+    """Append one loadable browser device or preset to a return track's chain.
+
+    Obtain `item_uri` from search_browser. Loading selects the return track in
+    Live and creates a new device, so repeated calls add duplicates. Prefer audio
+    effects on returns; use load_instrument_or_effect for a regular track or
+    load_device_to_master for the Master chain.
+    """
     r = get_ableton_connection().send_command(
         "load_device_to_return", {"return_index": return_index, "item_uri": item_uri}
     )
@@ -92,11 +118,20 @@ def get_master_device_parameters(ctx: Context, device_index: int) -> str:
     )
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
 def set_master_device_parameter(
-    ctx: Context, device_index: int, parameter: str | int, value: float
+    ctx: Context,
+    device_index: DeviceIndex,
+    parameter: DeviceParameter,
+    value: DeviceParameterValue,
 ) -> str:
-    """Set a parameter on a Master-track device by name or index."""
+    """Set one enabled parameter on a device in the Master track's chain.
+
+    Call get_master_device_parameters first and use its parameter name/index and
+    native min/max; out-of-range values are clamped. This affects the full mix.
+    Use set_device_parameter for a regular track or
+    set_return_device_parameter for a return track.
+    """
     return _set_param(
         "set_master_device_parameter",
         "master ",
@@ -106,11 +141,20 @@ def set_master_device_parameter(
     )
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
 def set_return_device_parameter(
-    ctx: Context, return_index: int, device_index: int, parameter: str | int, value: float
+    ctx: Context,
+    return_index: ReturnIndex,
+    device_index: DeviceIndex,
+    parameter: DeviceParameter,
+    value: DeviceParameterValue,
 ) -> str:
-    """Set a parameter on a Return-track device by name or index."""
+    """Set one enabled parameter on a device in a return track's chain.
+
+    Call get_return_device_parameters first and use its parameter name/index and
+    native min/max; out-of-range values are clamped. Use set_device_parameter for
+    a regular track or set_master_device_parameter for the full-mix chain.
+    """
     return _set_param(
         "set_return_device_parameter",
         f"return {return_index} ",

--- a/ableton_live_mcp/tools/generators.py
+++ b/ableton_live_mcp/tools/generators.py
@@ -6,12 +6,43 @@ they carry zero Live-API risk and always compose with the primitive tools.
 
 import json
 import random
+from typing import Annotated, Literal
 
 from mcp.server.fastmcp import Context
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from ..app import mcp
 from ..connection import AbletonCommandError, get_ableton_connection
+from ._util import ClipIndex, TrackIndex
+
+ChordProgression = Annotated[
+    str,
+    Field(
+        min_length=1,
+        description='Dash-, comma-, or space-separated chord symbols, e.g. "Dm7-G7-Cmaj7".',
+    ),
+]
+BeatsPerChord = Annotated[
+    float,
+    Field(gt=0, description="Positive number of beats allocated to each chord."),
+]
+MidiCenterPitch = Annotated[
+    int,
+    Field(ge=0, le=127, description="MIDI pitch around which chord voicings are centered."),
+]
+MidiVelocity = Annotated[
+    int,
+    Field(ge=1, le=127, description="Base MIDI note velocity (1-127)."),
+]
+StrumAmount = Annotated[
+    float,
+    Field(ge=0, description="Beat offset between chord tones; 0 produces block chords."),
+]
+ChordRhythm = Annotated[
+    Literal["held", "stabs", "quarters"],
+    Field(description="Chord rhythm: held, two stabs per slot, or quarter-note hits."),
+]
 
 # ── music theory tables ──────────────────────────────────────────────
 
@@ -272,25 +303,25 @@ def generate_drum_pattern(
     return f"Wrote {n} notes ({style}, {bars} bars) to track {track_index} slot {clip_index}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
 def generate_chord_progression(
     ctx: Context,
-    track_index: int,
-    clip_index: int,
-    progression: str,
-    beats_per_chord: float = 4.0,
-    center_pitch: int = 60,
-    velocity: int = 62,
-    strum: float = 0.02,
-    rhythm: str = "held",
+    track_index: TrackIndex,
+    clip_index: ClipIndex,
+    progression: ChordProgression,
+    beats_per_chord: BeatsPerChord = 4.0,
+    center_pitch: MidiCenterPitch = 60,
+    velocity: MidiVelocity = 62,
+    strum: StrumAmount = 0.02,
+    rhythm: ChordRhythm = "held",
 ) -> str:
-    """Write a chord progression into a Session clip. REPLACES existing notes.
+    """Generate voiced chords and write them into one Session-view MIDI clip.
 
-    progression: dash- or comma-separated symbols, e.g. "Am9-Fmaj7-Cmaj9-G13"
-    or "Dm7, G7, Cmaj7". Qualities: maj7/m7/m9/9/13/7#9/sus4/dim/add9 etc.
-    rhythm: "held" (one chord per slot), "stabs" (hit on 1 and the and-of-3),
-    "quarters" (four hits per bar, velocity-tapered).
-    strum: seconds-ish stagger between chord tones (0 = block chord).
+    DESTRUCTIVE: creates a clip when the slot is empty; otherwise resizes its loop
+    and replaces every existing note. The track must accept MIDI. Progressions
+    accept dash/comma/space-separated symbols such as `Am9-Fmaj7-Cmaj9-G13`;
+    supported qualities include maj7, m7, m9, 9, 13, 7#9, sus4, dim, and add9.
+    Use add_notes_to_clip for exact notes or edit_notes to preserve existing ones.
     """
     symbols = _split_progression(progression)
     notes = []

--- a/ableton_live_mcp/tools/session.py
+++ b/ableton_live_mcp/tools/session.py
@@ -7,14 +7,28 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import get_ableton_connection
-from ._util import params
+from ._util import (
+    ArrangementBeat,
+    DisplayName,
+    OptionalDisplayName,
+    PositiveBeatLength,
+    SceneIndex,
+    TimeSignatureDenominator,
+    TimeSignatureNumerator,
+    ToggleState,
+    params,
+)
 
 
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
 def get_session_info(ctx: Context) -> str:
-    """Get detailed information about the current Ableton session
+    """Return global Live-set and transport state without modifying the set.
 
-    Parameters:
+    Includes tempo, song time signature, playback position/state, Arrangement
+    loop, track/return/scene counts, scene names, key/scale, record mode, launch
+    quantization, Master volume/pan, and Live version. Use get_track_info for a
+    single track's clips/devices, or get_session_snapshot for a compact overview
+    of every track.
     """
     ableton = get_ableton_connection()
     result = ableton.send_command("get_session_info")
@@ -63,10 +77,14 @@ def create_scene(ctx: Context, index: int = -1) -> str:
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def create_locator(ctx: Context, time: float, name: str | None = None) -> str:
-    """Create an arrangement locator (marker) at a beat time, optionally named.
-    SIDE EFFECT: moves the arrangement playhead to `time` (Live places cues at
-    the playhead)."""
+def create_locator(ctx: Context, time: ArrangementBeat, name: OptionalDisplayName = None) -> str:
+    """Create or rename an Arrangement locator at an absolute beat position.
+
+    SIDE EFFECT: first moves the Arrangement playhead to `time`, because Live
+    creates cues at the playhead. If a locator already exists there, it is reused
+    and renamed when `name` is provided. Use set_arrangement_time when only the
+    playhead should move, and get_locators to inspect existing markers.
+    """
     conn = get_ableton_connection()
     # Move the playhead first (separate command) so it settles before the cue is
     # placed - set_or_delete_cue reads the live playhead position.
@@ -75,34 +93,63 @@ def create_locator(ctx: Context, time: float, name: str | None = None) -> str:
     return f"Locator '{r.get('name')}' at beat {r.get('time')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def fire_scene(ctx: Context, scene_index: int) -> str:
-    """Launch a scene (fires every clip in that row)."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def fire_scene(ctx: Context, scene_index: SceneIndex) -> str:
+    """Launch a Session-view scene using Live's launch quantization.
+
+    This fires the row's clips together and can replace or stop clips currently
+    playing on the affected tracks according to each slot's launch behavior.
+    Use fire_clip to launch only one track's clip, or start_playback when the
+    intent is Arrangement transport rather than Session launching.
+    """
     get_ableton_connection().send_command("fire_scene", {"scene_index": scene_index})
     return f"Fired scene {scene_index}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_scene_name(ctx: Context, scene_index: int, name: str) -> str:
-    """Rename a scene."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_scene_name(ctx: Context, scene_index: SceneIndex, name: DisplayName) -> str:
+    """Rename one Session-view scene without changing any clips in the row.
+
+    Use set_clip_name for an individual clip. Repeating the same name has no
+    additional effect.
+    """
     get_ableton_connection().send_command(
         "set_scene_name", {"scene_index": scene_index, "name": name}
     )
     return f"Scene {scene_index} named '{name}'"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_time_signature(ctx: Context, numerator: int, denominator: int) -> str:
-    """Set the song time signature (e.g. 4/4, 3/4, 6/8)."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_time_signature(
+    ctx: Context,
+    numerator: TimeSignatureNumerator,
+    denominator: TimeSignatureDenominator,
+) -> str:
+    """Set the Live set's global time signature, such as 4/4, 3/4, or 6/8.
+
+    This changes bar/grid and metronome interpretation but does not rewrite clip
+    notes. Use set_clip_signature instead when only one clip needs a different
+    meter for polymeter. Repeating the same signature has no additional effect.
+    """
     r = get_ableton_connection().send_command(
         "set_time_signature", {"numerator": numerator, "denominator": denominator}
     )
     return f"Time signature {r.get('numerator')}/{r.get('denominator')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_loop(ctx: Context, start: float, length: float, enabled: bool = True) -> str:
-    """Set the arrangement loop region (in beats) and enable/disable looping."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_loop(
+    ctx: Context,
+    start: ArrangementBeat,
+    length: PositiveBeatLength,
+    enabled: ToggleState = True,
+) -> str:
+    """Set the global Arrangement loop region and its enabled state.
+
+    `start` is an absolute beat and `length` is a positive beat duration. The
+    region is updated even when `enabled=false`; playback simply will not repeat
+    it. Use set_clip_loop for a Session clip's loop braces, not the Arrangement.
+    """
     r = get_ableton_connection().send_command(
         "set_loop", {"start": start, "length": length, "enabled": enabled}
     )
@@ -111,7 +158,13 @@ def set_loop(ctx: Context, start: float, length: float, enabled: bool = True) ->
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
 def undo(ctx: Context) -> str:
-    """Undo the last action in Live."""
+    """Revert the most recent undoable Live-set action.
+
+    This mutates the set and may remove newly created content or restore deleted
+    content. It has no target parameter: Live chooses the top undo-history entry.
+    Use redo to reapply an accidental undo. Prefer batch_commands for related
+    edits so one undo reverts the group.
+    """
     get_ableton_connection().send_command("undo")
     return "Undone"
 
@@ -185,10 +238,15 @@ def back_to_arranger(ctx: Context) -> str:
     return "Playback control returned to the Arrangement"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_record_mode(ctx: Context, enabled: bool) -> str:
-    """Toggle Arrangement record. With record_mode on, start_playback records
-    armed tracks into the Arrangement."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_record_mode(ctx: Context, enabled: ToggleState) -> str:
+    """Arm or disarm Live's global Arrangement Record state.
+
+    `true` enables Arrangement recording; `false` disables it. Enabling alone
+    does not record: arm the intended tracks with set_track_arm, then use
+    start_playback. Use set_session_record or trigger_session_record for Session
+    slots instead. Repeating the current state has no additional effect.
+    """
     r = get_ableton_connection().send_command("set_record_mode", {"enabled": enabled})
     return f"Arrangement record: {r.get('record_mode')}"
 
@@ -224,9 +282,14 @@ def delete_scene(ctx: Context, scene_index: int) -> str:
     return f"Scene deleted. Remaining: {r.get('scene_count')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def duplicate_scene(ctx: Context, scene_index: int) -> str:
-    """Duplicate a scene with all its clips - instant section variation."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def duplicate_scene(ctx: Context, scene_index: SceneIndex) -> str:
+    """Insert a copy of one Session scene, including every clip in its row.
+
+    This creates new content and increases the scene count; later scene indices
+    shift to make room. Use duplicate_track for a whole track or duplicate_clip_to
+    for one clip. Use the new scene as an editable section variation.
+    """
     r = get_ableton_connection().send_command("duplicate_scene", {"scene_index": scene_index})
     return f"Scene duplicated. Total: {r.get('scene_count')}"
 

--- a/ableton_live_mcp/tools/tracks.py
+++ b/ableton_live_mcp/tools/tracks.py
@@ -7,15 +7,18 @@ from mcp.types import ToolAnnotations
 
 from ..app import mcp
 from ..connection import get_ableton_connection
+from ._util import CrossfadeAssignment, PanValue, ToggleState, TrackIndex, TrackInsertIndex
 
 
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-def get_track_info(ctx: Context, track_index: int) -> str:
-    """
-    Get detailed information about a specific track in Ableton.
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True))
+def get_track_info(ctx: Context, track_index: TrackIndex) -> str:
+    """Return detailed state for one regular track without modifying the set.
 
-    Parameters:
-    - track_index: The index of the track to get information about
+    Includes name/type, mixer and arm/mute/solo state, sends, freeze/color state,
+    playing/fired slot indices, every Session slot's basic clip state, and the
+    device-chain names/types. Use get_session_info for global transport state,
+    get_device_parameters for parameter values, or get_clip_info for full clip
+    properties.
     """
     ableton = get_ableton_connection()
     result = ableton.send_command("get_track_info", {"track_index": track_index})
@@ -65,27 +68,42 @@ def set_track_volume(ctx: Context, track_index: int, volume: float) -> str:
     return f"Track {track_index} volume set to {result.get('volume')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_track_pan(ctx: Context, track_index: int, pan: float) -> str:
-    """Set track panning, -1.0 (left) to 1.0 (right)."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_track_pan(ctx: Context, track_index: TrackIndex, pan: PanValue) -> str:
+    """Set one regular track's stereo pan position; 0.0 is centered.
+
+    Live clamps the value to the track's native range. This changes mixer state,
+    not the audio file or clip content. Use set_master_device_parameter for a
+    device control, and set_crossfader for A/B crossfading.
+    """
     result = get_ableton_connection().send_command(
         "set_track_pan", {"track_index": track_index, "pan": pan}
     )
     return f"Track {track_index} pan set to {result.get('panning')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_track_mute(ctx: Context, track_index: int, mute: bool) -> str:
-    """Mute or unmute a track."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_track_mute(ctx: Context, track_index: TrackIndex, mute: ToggleState) -> str:
+    """Set one regular track's mute state (`true` mutes; `false` unmutes).
+
+    Muting silences that track in Live but preserves its clips, devices, and
+    mixer settings. Use set_track_solo to audition a track relative to the rest,
+    or stop_clip when only Session clip playback should stop.
+    """
     result = get_ableton_connection().send_command(
         "set_track_mute", {"track_index": track_index, "mute": mute}
     )
     return f"Track {track_index} mute: {result.get('mute')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_track_solo(ctx: Context, track_index: int, solo: bool) -> str:
-    """Solo or unsolo a track."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_track_solo(ctx: Context, track_index: TrackIndex, solo: ToggleState) -> str:
+    """Set one regular track's solo state (`true` solos; `false` unsolos).
+
+    Solo changes monitoring relative to other tracks and does not alter clip or
+    device content. Other tracks may remain soloed, so clear them separately when
+    exclusive auditioning is required. Use set_track_mute to silence this track.
+    """
     result = get_ableton_connection().send_command(
         "set_track_solo", {"track_index": track_index, "solo": solo}
     )
@@ -122,9 +140,14 @@ def delete_return_track(ctx: Context, return_index: int) -> str:
     return f"Return track deleted. Total returns: {r.get('return_track_count')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def create_audio_track(ctx: Context, index: int = -1) -> str:
-    """Create a new audio track. index -1 appends at the end."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def create_audio_track(ctx: Context, index: TrackInsertIndex = -1) -> str:
+    """Insert an empty audio track at a chosen position, or append with `-1`.
+
+    Non-negative indices insert before the current track at that position and
+    shift it and later track indices up. Use create_midi_track for instruments
+    and MIDI clips, or create_return_track for a shared send-effect bus.
+    """
     r = get_ableton_connection().send_command("create_audio_track", {"index": index})
     return f"Audio track created. Total tracks: {r.get('track_count')}"
 
@@ -144,9 +167,14 @@ def set_track_color(ctx: Context, track_index: int, color_index: int) -> str:
     return f"Track {track_index} color set"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def duplicate_track(ctx: Context, track_index: int) -> str:
-    """Duplicate a track along with its devices and clips."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+def duplicate_track(ctx: Context, track_index: TrackIndex) -> str:
+    """Insert a copy of one regular track, including its devices and clips.
+
+    This creates new content and increases the track count; later track indices
+    shift to make room. Use duplicate_scene for a Session row or duplicate_clip_to
+    for one clip. Rename or edit the copy to create a variation.
+    """
     r = get_ableton_connection().send_command("duplicate_track", {"track_index": track_index})
     return f"Track duplicated. Total tracks: {r.get('track_count')}"
 
@@ -221,9 +249,14 @@ def set_crossfader(ctx: Context, value: float) -> str:
     return f"Crossfader: {r.get('crossfader')}"
 
 
-@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-def set_crossfade_assign(ctx: Context, track_index: int, assign: int) -> str:
-    """Assign a track to the crossfader: 0=A, 1=none, 2=B."""
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+def set_crossfade_assign(ctx: Context, track_index: TrackIndex, assign: CrossfadeAssignment) -> str:
+    """Assign one regular track to crossfader side A, neither side, or side B.
+
+    This configures which side affects the track; it does not move the crossfader
+    or change track volume immediately. Use set_crossfader afterward to blend the
+    A/B groups. Repeating the same assignment has no additional effect.
+    """
     r = get_ableton_connection().send_command(
         "set_crossfade_assign", {"track_index": track_index, "assign": assign}
     )

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "wstierhout"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,35 @@
 [project]
 name = "mcp-server-ableton-live"
 version = "1.7.2"
-description = "Ableton Live integration through the Model Context Protocol"
+description = "Control Ableton Live with AI using typed MCP tools for MIDI, mixing, mastering, and offline .als analysis"
 readme = "README.md"
 requires-python = ">=3.10"
+keywords = [
+    "ableton",
+    "ableton-live",
+    "ai-music",
+    "daw",
+    "mcp",
+    "midi",
+    "model-context-protocol",
+    "music-production",
+]
 authors = [
     {name = "Wouter Stierhout"},
 ]
 license = "MIT"
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: End Users/Desktop",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Sound/Audio :: MIDI",
 ]
 dependencies = [
     "mcp[cli]>=1.9.0,<2",
@@ -32,6 +51,9 @@ packages = ["ableton_live_mcp", "ableton_live_mcp.tools", "ableton_live_mcp.remo
 
 [project.urls]
 "Homepage" = "https://github.com/wstierhout/ableton-live-mcp"
+"Documentation" = "https://github.com/wstierhout/ableton-live-mcp#readme"
+"Changelog" = "https://github.com/wstierhout/ableton-live-mcp/blob/main/CHANGELOG.md"
+"Glama" = "https://glama.ai/mcp/servers/wstierhout/ableton-live-mcp"
 "Bug Tracker" = "https://github.com/wstierhout/ableton-live-mcp/issues"
 [tool.ruff]
 line-length = 100

--- a/server.json
+++ b/server.json
@@ -2,7 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.wstierhout/ableton-live-mcp",
   "title": "Ableton Live MCP Server",
-  "description": "Control Ableton Live from an AI assistant: 154 tools for building, mixing, and mastering, plus offline .als analysis.",
+  "description": "Control Ableton Live with 154 typed tools for music production and offline .als analysis.",
+  "websiteUrl": "https://github.com/wstierhout/ableton-live-mcp#readme",
   "repository": {
     "url": "https://github.com/wstierhout/ableton-live-mcp",
     "source": "github"

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -2,6 +2,38 @@
 
 import asyncio
 
+GLAMA_REVIEWED_TOOLS = {
+    "clear_automation",
+    "create_audio_track",
+    "create_locator",
+    "delete_clip",
+    "duplicate_scene",
+    "duplicate_track",
+    "fire_clip",
+    "fire_scene",
+    "generate_chord_progression",
+    "get_clip_notes",
+    "get_session_info",
+    "get_track_info",
+    "load_device_to_return",
+    "load_drum_kit",
+    "set_clip_color",
+    "set_clip_loop",
+    "set_clip_name",
+    "set_crossfade_assign",
+    "set_device_enabled",
+    "set_loop",
+    "set_master_device_parameter",
+    "set_record_mode",
+    "set_return_device_parameter",
+    "set_scene_name",
+    "set_time_signature",
+    "set_track_mute",
+    "set_track_pan",
+    "set_track_solo",
+    "undo",
+}
+
 
 def test_tool_registration():
     from ableton_live_mcp import tools as _tools  # noqa: F401  (registers the tools)
@@ -49,3 +81,32 @@ def test_version_consistency():
     server = json.loads((root / "server.json").read_text())
     assert server["version"] == __version__
     assert server["packages"][0]["version"] == __version__
+    assert len(server["description"]) <= 100, "Official MCP Registry limit"
+    assert server["websiteUrl"] == "https://github.com/wstierhout/ableton-live-mcp#readme"
+
+
+def test_glama_reviewed_tools_have_documented_input_schemas():
+    """Keep the parameter-description gap fixed for every tool Glama rated B/C."""
+    from ableton_live_mcp import tools as _tools  # noqa: F401
+    from ableton_live_mcp.app import mcp
+
+    by_name = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+    assert GLAMA_REVIEWED_TOOLS <= by_name.keys()
+
+    missing = []
+    for name in sorted(GLAMA_REVIEWED_TOOLS):
+        for parameter, schema in by_name[name].inputSchema.get("properties", {}).items():
+            if not schema.get("description"):
+                missing.append(f"{name}.{parameter}")
+    assert not missing, f"missing input-schema descriptions: {', '.join(missing)}"
+
+
+def test_glama_metadata_claims_repository_owner():
+    import json
+    import pathlib
+
+    metadata = json.loads((pathlib.Path(__file__).parent.parent / "glama.json").read_text())
+    assert metadata == {
+        "$schema": "https://glama.ai/mcp/schemas/server.json",
+        "maintainers": ["wstierhout"],
+    }


### PR DESCRIPTION
## Changes

- add `glama.json` ownership metadata and a Glama quality badge
- improve all 29 B/C-rated tool descriptions, JSON Schemas, constraints, and annotations
- add regression tests for reviewed tool schemas and Glama metadata
- strengthen PyPI metadata and add a concise README FAQ
- fix `server.json` metadata and update GitHub Actions to `actions/checkout@v5`

## Registry publishing fix

The Official MCP Registry limits `description` to 100 characters. Starting with 1.2.0, `server.json` used a 117-character description, so PyPI publication succeeded but Registry publication failed. The description is now schema-compliant and covered by a regression assertion.

## Verification

- `uv run pytest` — 84 passed
- `uv run ruff check .`
- `uv run ruff format --check ableton_live_mcp tests`
- `uv build`
- `git diff --check`